### PR TITLE
Undefined names: Add missing imports

### DIFF
--- a/baselines_energyplus/bench/monitor.py
+++ b/baselines_energyplus/bench/monitor.py
@@ -7,6 +7,9 @@ from glob import glob
 import csv
 import os.path as osp
 import json
+import os
+import uuid
+import pandas
 
 class Monitor(Wrapper):
     EXT = "monitor.csv"

--- a/baselines_energyplus/common/plot_energyplus.py
+++ b/baselines_energyplus/common/plot_energyplus.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # noinspection PyUnresolvedReferences
 import argparse
+import os
 
 from baselines_energyplus.common.energyplus_util import make_energyplus_env, energyplus_locate_log_dir
-#import os
 import gym_energyplus
 
 def plot_energyplus_arg_parser():

--- a/gym_energyplus/envs/energyplus_model.py
+++ b/gym_energyplus/envs/energyplus_model.py
@@ -246,7 +246,7 @@ class EnergyPlusModel(metaclass=ABCMeta):
             self.reward = []
             self.reward_mean = []
             self.episode_dirs = []
-            for rew, len, time in zip(df['r'], df['l'], df['t']):
+            for rew, len, time_ in zip(df['r'], df['l'], df['t']):
                 self.reward.append(rew / len)
                 self.reward_mean.append(rew / len)
                 self.episode_dirs.append(self.log_dir + '/output/episode-{:08d}'.format(self.num_episodes))


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/rl-testbed-for-energyplus on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./baselines_energyplus/common/plot_energyplus.py:24:9: F821 undefined name 'os'
        os.exit(1)
        ^
./baselines_energyplus/bench/monitor.py:140:55: F821 undefined name 'uuid'
    mon_file = "/tmp/baselines-test-%s.monitor.csv" % uuid.uuid4()
                                                      ^
./baselines_energyplus/bench/monitor.py:156:20: F821 undefined name 'pandas'
    last_logline = pandas.read_csv(f, index_col=None)
                   ^
./baselines_energyplus/bench/monitor.py:159:5: F821 undefined name 'os'
    os.remove(mon_file)    ^
./gym_energyplus/envs/energyplus_model_2ZoneDataCenterHVAC_wEconomizer_Temp.py:553:222: F821 undefined name 'In22_25_1'
                f.write('"{}" {:5.2f} {:5.2f} {:5.2f} {:4.2f} {:5.2f} {:5.2f} {:5.2f} {:4.2f} {:5.2f} {:9.2f} {:8.3%} {:8.3%} {:3d}\n'.format(self.weather_key, Ave1, Min1, Max1, STD1, Ave2,  Min2, Max2, STD2, Rew, Power, In22_25_1, In22_25_2, ep))
                                                                                                                                                                                                                             ^
./gym_energyplus/envs/energyplus_model.py:228:17: F823 local variable 'time' (defined in enclosing scope on line 6) referenced before assignment
                time.sleep(1)
                ^
5     F821 undefined name 'uuid'
1     F823 local variable 'time' (defined in enclosing scope on line 6) referenced before assignment
6
```