### PR TITLE
First line of monitoring file not being written

### DIFF
--- a/baselines_energyplus/bench/monitor.py
+++ b/baselines_energyplus/bench/monitor.py
@@ -27,6 +27,7 @@ class Monitor(Wrapper):
                     filename = filename + "." + Monitor.EXT
             self.f = open(filename, "wt")
             self.f.write('#%s\n'%json.dumps({"t_start": self.tstart, 'env_id' : env.spec and env.spec.id}))
+            self.f.flush()
             self.logger = csv.DictWriter(self.f, fieldnames=('r', 'l', 't')+reset_keywords)
             self.logger.writeheader()
 


### PR DESCRIPTION
Intermittently, header line in monitoring file isn't written after executing `python3 -m baselines_energyplus.trpo_mpi.run_energyplus --num-timesteps`.

Just added a `flush()` instruction so we can avoid having assertion errors when running `python3 -m baselines_energyplus.common.plot_energyplus`