### PR TITLE
skip system time steps

### DIFF
--- a/EnergyPlus/RL-patch-for-EnergyPlus-9-1-0.patch
+++ b/EnergyPlus/RL-patch-for-EnergyPlus-9-1-0.patch
@@ -60,10 +60,10 @@ index a7e05f139..a3f7e7999 100644
          // na
 diff --git a/src/EnergyPlus/ExtCtrl.cc b/src/EnergyPlus/ExtCtrl.cc
 new file mode 100644
-index 000000000..bd2c38502
+index 000000000..c4731a288
 --- /dev/null
 +++ b/src/EnergyPlus/ExtCtrl.cc
-@@ -0,0 +1,290 @@
+@@ -0,0 +1,301 @@
 +// EnergyPlus, Copyright (c) 1996-2019, The Board of Trustees of the University of Illinois,
 +// The Regents of the University of California, through Lawrence Berkeley National Laboratory
 +// (subject to receipt of any required approvals from the U.S. Dept. of Energy), Oak Ridge
@@ -126,6 +126,8 @@ index 000000000..bd2c38502
 +#include <CommandLineInterface.hh>
 +#include <ExtCtrl.hh>
 +#include <DataEnvironment.hh>
++#include <DataGlobals.hh>
++#include <DataHVACGlobals.hh>
 +#include <DataPrecisionGlobals.hh>
 +#include <General.hh>
 +#include <UtilityRoutines.hh>
@@ -157,6 +159,10 @@ index 000000000..bd2c38502
 +	// Data
 +	// MODULE PARAMETER DEFINITIONS:
 +	// For sending observation
++
++	using DataGlobals::TimeStepZone;
++	using DataHVACGlobals::TimeStepSys;
++
 +	int const CMD_OBS_INIT(0);
 +	int const NUM_OBSS(100);
 +	int const CMD_OBS_INDEX_LOW(1);
@@ -311,7 +317,7 @@ index 000000000..bd2c38502
 +	)
 +	{
 +		Int64 cmdInt = cmd;
-+		Int64 ArgInt = arg;
++		Int64 argInt = arg;
 +
 +		if (InitializeExtCtrlRoutines()) {
 +			return -1.0;
@@ -321,13 +327,18 @@ index 000000000..bd2c38502
 +			return acts[cmdInt - 1];
 +		}
 +		else if (cmdInt == CMD_ACT_REQ) {
-+			if (!(ArgInt >= 0 && ArgInt <= CMD_ACT_INDEX_HIGH)) {
-+				ShowWarningMessage("ExtCtrlAct: Number of obss " + std::to_string(ArgInt) + " must be in range [0..." + std::to_string(CMD_ACT_INDEX_HIGH) + "]");
++			if (!(argInt >= 0 && argInt <= CMD_ACT_INDEX_HIGH)) {
++				ShowWarningMessage("ExtCtrlAct: Number of obss " + std::to_string(argInt) + " must be in range [0..." + std::to_string(CMD_ACT_INDEX_HIGH) + "]");
 +				return -1.0;
 +			}
++			// skip system timestep
++			if (TimeStepSys < TimeStepZone) {
++				return 0.0;
++			}
++
 +			// Send observation data to the server, and receive next action.
-+			ExtCtrlWrite(std::to_string(ArgInt));
-+			for (int i = CMD_ACT_INDEX_LOW; i <= ArgInt; i++) {
++			ExtCtrlWrite(std::to_string(argInt));
++			for (int i = CMD_ACT_INDEX_LOW; i <= argInt; i++) {
 +				ExtCtrlWrite(std::to_string(obss[i - 1]));
 +			}
 +			ExtCtrlFlush();

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You need to download ver. 9.1.0 from https://github.com/NREL/EnergyPlus/releases
 $ cd <DOWNLOAD-DIRECTORY>
 $ patch -p0 < rl-testbed-for-energyplus/EnergyPlus/EnergyPlus-9.1.0-08d2e308bb-Linux-x86_64.sh.patch
 ```
-3. Execute installation image.
+4. Execute installation image.
 ```
 $ sudo bash <DOWNLOAD-DIRECTORY>/EnergyPlus-9.1.0-08d2e308bb-Linux-x86_64.sh
 ```


### PR DESCRIPTION
Skip EnergyPlus system time steps and act only on control time step.

Fixes #9 

Signed-off-by: Antoine Galataud <antoine@foobot.io>