### PR TITLE
Dockerfile for simple installation and experiment run

### DIFF
--- a/baselines_energyplus/trpo_mpi/run_energyplus.py
+++ b/baselines_energyplus/trpo_mpi/run_energyplus.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # noinspection PyUnresolvedReferences
+import sys
+
 from mpi4py import MPI
 from baselines_energyplus.common.energyplus_util import make_energyplus_env, energyplus_arg_parser, energyplus_logbase_dir
 from baselines import logger
@@ -27,11 +29,11 @@ def train(env_id, num_timesteps, seed):
     model = os.getenv('ENERGYPLUS_MODEL')
     if model is None:
         print('Environment variable ENERGYPLUS_MODEL is not defined')
-        os.exit()
+        sys.exit(1)
     weather = os.getenv('ENERGYPLUS_WEATHER')
     if weather is None:
         print('Environment variable ENERGYPLUS_WEATHER is not defined')
-        os.exit()
+        sys.exit(1)
 
     rank = MPI.COMM_WORLD.Get_rank()
     if rank == 0:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN apt update && \
 RUN ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts && \
     git clone --depth=1 -b v$EPLUS_VERSION https://github.com/NREL/EnergyPlus.git && \
     # get rl-testbed-for-energyplus sources
-    git clone --depth=1 -b $RL_TESTBED_BRANCH https://github.com/IBM/rl-testbed-for-energyplus.git ./rl-testbed-for-energyplus
+    git clone --depth=1 -b $RL_TESTBED_BRANCH https://github.com/antoine-galataud/rl-testbed-for-energyplus.git ./rl-testbed-for-energyplus
 
 WORKDIR /root/EnergyPlus
 
@@ -35,13 +35,20 @@ RUN patch -p1 < ../rl-testbed-for-energyplus/EnergyPlus/RL-patch-for-EnergyPlus-
 
 WORKDIR /root
 
-# free space, install python dependencies
+# install python dependencies
+RUN apt install -y python3-mpi4py && \
+    pip3 install -U pip && \
+    cd ./rl-testbed-for-energyplus && \
+    # installing deps in 2 steps:
+    # - baselines 0.1.5 brings mujoco (not needed here), so we have to use 0.1.6 (which has no wheel, so from git)
+    # - baselines requires tensorflow installed first, so have to make sure order is respected (not possible with -r)
+    cat requirements.txt | grep -v baselines | xargs pip3 install && \
+    cat requirements.txt | grep baselines | xargs pip3 install
+
+# cleanup
 RUN rm -rf EnergyPlus && \
     rm $(echo "$EPLUS_DL_URL" | rev | cut -d'/' -f1 | rev) && \
     apt remove -y build-essential cmake wget && \
-    apt autoremove -y && \
-    pip3 install -U pip && \
-    cd ./rl-testbed-for-energyplus && \
-    pip3 install -r requirements.txt
+    apt autoremove -y
 
 ENTRYPOINT "/bin/bash"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,8 @@ ARG RL_TESTBED_BRANCH=master
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+COPY bashrc_eplus /root/.bashrc_eplus
+
 WORKDIR /root
 
 RUN apt update && \
@@ -44,7 +46,8 @@ RUN apt install -y python3-mpi4py && \
     # - baselines 0.1.5 brings mujoco (not needed here), so we have to use 0.1.6 (which has no wheel, so from git)
     # - baselines requires tensorflow installed first
     cat requirements.txt | grep -v baselines | xargs pip3 install && \
-    cat requirements.txt | grep baselines | xargs pip3 install
+    cat requirements.txt | grep baselines | xargs pip3 install && \
+    echo "source .bashrc_eplus" >> /root/.bashrc
 
 # cleanup
 RUN rm -rf EnergyPlus && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN apt update && \
 RUN ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts && \
     git clone --depth=1 -b v$EPLUS_VERSION https://github.com/NREL/EnergyPlus.git && \
     # get rl-testbed-for-energyplus sources
-    git clone --depth=1 -b $RL_TESTBED_BRANCH https://github.com/antoine-galataud/rl-testbed-for-energyplus.git ./rl-testbed-for-energyplus
+    git clone --depth=1 -b $RL_TESTBED_BRANCH https://github.com/IBM/rl-testbed-for-energyplus.git ./rl-testbed-for-energyplus
 
 WORKDIR /root/EnergyPlus
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:18.04
 ARG EPLUS_VERSION=9.2.0
 ARG EPLUS_DL_URL=https://github.com/NREL/EnergyPlus/releases/download/v9.2.0/EnergyPlus-9.2.0-921312fa1d-Linux-x86_64.sh
 ARG EPLUS_BUILD_PARALLELISM=4
+ARG RL_TESTBED_BRANCH=master
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -11,15 +12,15 @@ WORKDIR /root
 RUN apt update && \
     apt install -y -u build-essential cmake python3-minimal python3-pip wget openssh-client git && \
     # necessary so cmake can find python binary
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     # install E+ from binaries
     wget --quiet $EPLUS_DL_URL && \
-    (echo "y"; echo ""; echo "";) | bash $(echo "$EPLUS_DL_URL" | rev | cut -d'/' -f1 | rev).sh && \
+    (echo "y"; echo ""; echo "";) | bash $(echo "$EPLUS_DL_URL" | rev | cut -d'/' -f1 | rev) && \
     # get E+ sources
     ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts && \
     git clone --depth=1 -b v$EPLUS_VERSION https://github.com/NREL/EnergyPlus.git && \
     # get rl-testbed-for-energyplus sources
-    git clone --depth=1 git@github.com:IBM/rl-testbed-for-energyplus.git ./rl-testbed-for-energyplus
+    git clone --depth=1 -b $RL_TESTBED_BRANCH https://github.com/IBM/rl-testbed-for-energyplus.git ./rl-testbed-for-energyplus
 
 WORKDIR /root/EnergyPlus
 
@@ -35,7 +36,7 @@ WORKDIR /root
 
 # free space, install python dependencies
 RUN rm -rf EnergyPlus && \
-    rm $(echo "$EPLUS_DL_URL" | rev | cut -d'/' -f1 | rev).sh && \
+    rm $(echo "$EPLUS_DL_URL" | rev | cut -d'/' -f1 | rev) && \
     apt remove -y build-essential cmake wget && \
     apt autoremove -y && \
     pip3 install -U pip && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,10 @@ RUN apt update && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     # install E+ from binaries
     wget --quiet $EPLUS_DL_URL && \
-    (echo "y"; echo ""; echo "";) | bash $(echo "$EPLUS_DL_URL" | rev | cut -d'/' -f1 | rev) && \
-    # get E+ sources
-    ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts && \
+    (echo "y"; echo ""; echo "";) | bash $(echo "$EPLUS_DL_URL" | rev | cut -d'/' -f1 | rev)
+
+# get E+ and rl-testbed-for-energyplussources
+RUN ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts && \
     git clone --depth=1 -b v$EPLUS_VERSION https://github.com/NREL/EnergyPlus.git && \
     # get rl-testbed-for-energyplus sources
     git clone --depth=1 -b $RL_TESTBED_BRANCH https://github.com/IBM/rl-testbed-for-energyplus.git ./rl-testbed-for-energyplus

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /root
 
 RUN apt update && \
-    apt install -y -u build-essential cmake python3-minimal python3-pip wget openssh-client git && \
+    apt install -y -u build-essential cmake python3-minimal python3-pip wget openssh-client git \
+                      libgl1-mesa-glx && \
     # necessary so cmake can find python binary
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     # install E+ from binaries
@@ -41,7 +42,7 @@ RUN apt install -y python3-mpi4py && \
     cd ./rl-testbed-for-energyplus && \
     # installing deps in 2 steps:
     # - baselines 0.1.5 brings mujoco (not needed here), so we have to use 0.1.6 (which has no wheel, so from git)
-    # - baselines requires tensorflow installed first, so have to make sure order is respected (not possible with -r)
+    # - baselines requires tensorflow installed first
     cat requirements.txt | grep -v baselines | xargs pip3 install && \
     cat requirements.txt | grep baselines | xargs pip3 install
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:18.04
+
+ARG EPLUS_VERSION=9.2.0
+ARG EPLUS_DL_URL=https://github.com/NREL/EnergyPlus/releases/download/v9.2.0/EnergyPlus-9.2.0-921312fa1d-Linux-x86_64.sh
+ARG EPLUS_BUILD_PARALLELISM=4
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /root
+
+RUN apt update && \
+    apt install -y -u build-essential cmake python3-minimal python3-pip wget openssh-client git && \
+    # necessary so cmake can find python binary
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 && \
+    # install E+ from binaries
+    wget --quiet $EPLUS_DL_URL && \
+    (echo "y"; echo ""; echo "";) | bash $(echo "$EPLUS_DL_URL" | rev | cut -d'/' -f1 | rev).sh && \
+    # get E+ sources
+    ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts && \
+    git clone --depth=1 -b v$EPLUS_VERSION https://github.com/NREL/EnergyPlus.git && \
+    # get rl-testbed-for-energyplus sources
+    git clone --depth=1 git@github.com:IBM/rl-testbed-for-energyplus.git ./rl-testbed-for-energyplus
+
+WORKDIR /root/EnergyPlus
+
+# build patched E+
+RUN patch -p1 < ../rl-testbed-for-energyplus/EnergyPlus/RL-patch-for-EnergyPlus-$(echo "$EPLUS_VERSION" | tr '.' '-').patch && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/local/EnergyPlus-$(echo "$EPLUS_VERSION" | tr '.' '-') .. && \
+    make -j$EPLUS_BUILD_PARALLELISM && \
+    make install
+
+WORKDIR /root
+
+# free space, install python dependencies
+RUN rm -rf EnergyPlus && \
+    rm $(echo "$EPLUS_DL_URL" | rev | cut -d'/' -f1 | rev).sh && \
+    apt remove -y build-essential cmake wget && \
+    apt autoremove -y && \
+    pip3 install -U pip && \
+    cd ./rl-testbed-for-energyplus && \
+    pip3 install -r requirements.txt
+
+ENTRYPOINT "/bin/bash"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,39 @@
+## Docker image usage instructions
+
+The docker image that can be built using `Dockerfile` allows to automate setup and ensure reproducible work 
+environment.
+
+### Building
+
+You need `docker` installed. Present procedure was built and tested on Ubuntu 18.04.
+
+Build image with:
+
+```shell
+docker build . -t rl-testbed-for-energyplus
+```
+
+The default EnergyPlus version used in the image is `9.2.0`. To use a different one, follow example below:
+
+```shell
+docker build . \
+  --build-arg EPLUS_VERSION=8.8.0 \
+  --build-arg EPLUS_DL_URL="<EnergyPlus download URL>" \
+  -t rl-testbed-for-energyplus
+```
+
+### Running
+
+The image can be used to run a training as it contains all necessary dependencies. For example, if you want to use 
+your own project sources to launch a training, you can first start docker image with project sources mounted as a 
+container volume:
+
+```shell
+docker run -t -i -v /path/to/project:/root/my-project rl-testbed-for-energyplus
+```
+
+Tip: simply use `$(pwd)` instead of `/path/to/project` if you want to mount the current directory.
+
+This starts the container and opens a `bash` shell. Then you can launch a training as documented in README.md at the root 
+of this project. All modifications you will make to your sources located on your hard drive will be reflected in running 
+docker container.

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,9 +24,17 @@ docker build . \
 
 ### Running
 
-The image can be used to run a training as it contains all necessary dependencies. For example, if you want to use 
-your own project sources to launch a training, you can first start docker image with project sources mounted as a 
-container volume:
+The image can be used to run a training as it contains all necessary dependencies. Run:
+
+```shell
+docker run -t -i rl-testbed-for-energyplus
+```
+
+to start the container and open a shell. Then `cd /root/rl-testbed-for-energyplus`, there you can launch a training as 
+documented in README.md.
+
+Another option is to use your own project sources to launch a training (e.g. you have forked present git repo). To do 
+so, you can start docker image with your project sources mounted as a container volume:
 
 ```shell
 docker run -t -i -v /path/to/project:/root/my-project rl-testbed-for-energyplus
@@ -34,6 +42,5 @@ docker run -t -i -v /path/to/project:/root/my-project rl-testbed-for-energyplus
 
 Tip: simply use `$(pwd)` instead of `/path/to/project` if you want to mount the current directory.
 
-This starts the container and opens a `bash` shell. Then you can launch a training as documented in README.md at the root 
-of this project. All modifications you will make to your sources located on your hard drive will be reflected in running 
+Note: all modifications you will make to your sources located on your hard drive will be reflected in the running 
 docker container.

--- a/docker/bashrc_eplus
+++ b/docker/bashrc_eplus
@@ -8,7 +8,9 @@ else
 	energyplus_instdir="/usr/local"
 fi
 
-ENERGYPLUS_VERSION="9-2-0"
+
+# deduce EnergyPlus version from its installation directory
+ENERGYPLUS_VERSION="$(ls -d ${energyplus_instdir}/EnergyPlus* |  cut -d'-' -f2-4)"
 ENERGYPLUS_DIR="${energyplus_instdir}/EnergyPlus-${ENERGYPLUS_VERSION}"
 WEATHER_DIR="${ENERGYPLUS_DIR}/WeatherData"
 export ENERGYPLUS="${ENERGYPLUS_DIR}/energyplus"

--- a/docker/bashrc_eplus
+++ b/docker/bashrc_eplus
@@ -1,0 +1,32 @@
+# Specify the top directory
+TOP=/root/rl-testbed-for-energyplus
+export PYTHONPATH=${PYTHONPATH}:${TOP}
+
+if [ `uname` == "Darwin" ]; then
+	energyplus_instdir="/Applications"
+else
+	energyplus_instdir="/usr/local"
+fi
+
+ENERGYPLUS_VERSION="9-2-0"
+ENERGYPLUS_DIR="${energyplus_instdir}/EnergyPlus-${ENERGYPLUS_VERSION}"
+WEATHER_DIR="${ENERGYPLUS_DIR}/WeatherData"
+export ENERGYPLUS="${ENERGYPLUS_DIR}/energyplus"
+MODEL_DIR="${TOP}/EnergyPlus/Model-${ENERGYPLUS_VERSION}"
+
+# Weather file.
+# Single weather file or multiple weather files separated by comma character.
+export ENERGYPLUS_WEATHER="${WEATHER_DIR}/USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw"
+#export ENERGYPLUS_WEATHER="${WEATHER_DIR}/USA_CO_Golden-NREL.724666_TMY3.epw"
+#export ENERGYPLUS_WEATHER="${WEATHER_DIR}/USA_FL_Tampa.Intl.AP.722110_TMY3.epw"
+#export ENERGYPLUS_WEATHER="${WEATHER_DIR}/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw"
+#export ENERGYPLUS_WEATHER="${WEATHER_DIR}/USA_VA_Sterling-Washington.Dulles.Intl.AP.724030_TMY3.epw"
+#export ENERGYPLUS_WEATHER="${WEATHER_DIR}/USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw,${WEATHER_DIR}/USA_CO_Golden-NREL.724666_TMY3.epw,${WEATHER_DIR}/USA_FL_Tampa.Intl.AP.722110_TMY3.epw"
+
+# Ouput directory "openai-YYYY-MM-DD-HH-MM-SS-mmmmmm" is created in
+# the directory specified by ENERGYPLUS_LOGBASE or in the current directory if not specified.
+export ENERGYPLUS_LOGBASE="${HOME}/eplog"
+
+# Model file. Uncomment one.
+#export ENERGYPLUS_MODEL="${MODEL_DIR}/2ZoneDataCenterHVAC_wEconomizer_Temp.idf"     # Temp. setpoint control
+export ENERGYPLUS_MODEL="${MODEL_DIR}/2ZoneDataCenterHVAC_wEconomizer_Temp_Fan.idf" # Temp. setpoint and fan control


### PR DESCRIPTION
This pull request provides a Dockerfile that can be used to setup a training environment in a single command. It also provides an isolated environment for safe execution and dependencies resolution (good bye python dependencies mess). 

Running an experiment can be done inside the docker container the exact same way we'd do it locally.

Note: it requires #54 to be closed first at it relies on the presence of requirements.txt to install python packages.