### PR TITLE
Docker eplus 22.1.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-ARG EPLUS_VERSION=9-6-0
-ARG EPLUS_DL_URL=https://github.com/NREL/EnergyPlus/releases/download/v9.6.0/EnergyPlus-9.6.0-f420c06a69-Linux-Ubuntu20.04-x86_64.sh
+ARG EPLUS_VERSION=22-1-0
+ARG EPLUS_DL_URL=https://github.com/NREL/EnergyPlus/releases/download/v22.1.0/EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu20.04-x86_64.sh
 
 # Stage 1
 FROM ubuntu:20.04 AS eplus-build
@@ -39,6 +39,9 @@ RUN apt update && \
 
 # Stage 2
 FROM ubuntu:20.04
+
+# connect package with repo
+LABEL org.opencontainers.image.source=https://github.com/IBM/rl-testbed-for-energyplus
 
 ARG EPLUS_VERSION
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,6 +3,18 @@
 The docker image that can be built using `Dockerfile` allows automating setup and ensures reproducible work 
 environment.
 
+### Pre-built images
+
+See the existing [list of docker images](https://github.com/users/antoine-galataud/packages/container/package/rl-testbed-for-energyplus)
+
+Usage example:
+
+```shell
+docker pull ghcr.io/antoine-galataud/rl-testbed-for-energyplus:ep22.1.0
+```
+
+where image tag `ep22.1.0` is the EnergyPlus version that the image is using.
+
 ### Building
 
 You need `docker` installed (ie `sudo apt install docker.io`).
@@ -14,11 +26,11 @@ cd rl-testbed-for-energyplus/
 docker build . -f docker/Dockerfile -t rl-testbed-for-energyplus
 ```
 
-The default EnergyPlus version used in the image is `9-6-0`. To use a different one, follow example below:
+The default EnergyPlus version used in the image is `22-1-0`. To use a different one, follow example below:
 
 ```shell
 docker build . \
-  --build-arg EPLUS_VERSION=9-5-0 \
+  --build-arg EPLUS_VERSION=9-6-0 \
   --build-arg EPLUS_DL_URL="<EnergyPlus download URL>" \
   -t rl-testbed-for-energyplus
 ```


### PR DESCRIPTION
Signed-off-by: Antoine Galataud [antoine@foobot.io](mailto:antoine@foobot.io)

Following #91, I've built and published a public docker image (see https://github.com/users/antoine-galataud/packages/container/package/rl-testbed-for-energyplus) so anyone can pull it and start working.

@takaomoriyama that would be nice to connect this new github package to the repository directly, so it appears on the front page. For that, one of the repo owners need to create the package first, or we could setup a github action.