### PR TITLE
Plot inside docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN export EPLUS_INSTALL_PATH=/usr/local/EnergyPlus-${EPLUS_VERSION} && \
     ln -s ${EPLUS_INSTALL_PATH}/ExpandObjects /usr/local/bin/ExpandObjects && \
     ln -s ${EPLUS_INSTALL_PATH}/ReadVarsESO /usr/local/bin/ReadVarsESO && \
     # install python dependencies
-    apt update && apt install -y locales python3-pip python3-mpi4py git libgl1-mesa-glx libglib2.0-0 && \
+    apt update && apt install -y locales python3-pip python3-mpi4py python3-tk git libgl1-mesa-glx libglib2.0-0 && \
     pip3 install -U pip && \
     # installing deps in 2 steps:
     # - baselines requires tensorflow installed first

--- a/docker/README.md
+++ b/docker/README.md
@@ -84,7 +84,7 @@ docker run -it \
     rl-testbed-for-energyplus
 ```
 
-Then run monitoring tool as usual (inside the container):
+Run the experiment, then run monitoring tool as usual (inside the container):
 
 ```shell
 python3 -m baselines_energyplus.common.plot_energyplus

--- a/docker/README.md
+++ b/docker/README.md
@@ -62,3 +62,32 @@ Tip: simply use `$(pwd)` instead of `/path/to/project` if you want to mount the 
 
 Note: all modifications you will make to your sources located on your hard drive will be reflected in the running 
 docker container.
+
+### Plotting
+
+If you want to monitor progress using plots from inside the docker container, this can be done in 3 steps (tested on Ubuntu, probably not working on MacOS):
+
+Make sure all clients can access your display:
+
+```shell
+sudo apt install x11-xserver-utils
+xhost +
+```
+
+Run the container so it can access your display:
+
+```shell
+docker run -it \
+    --env="QT_X11_NO_MITSHM=1" \
+    --env="DISPLAY" \
+    --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+    rl-testbed-for-energyplus
+```
+
+Then run monitoring tool as usual (inside the container):
+
+```shell
+python3 -m baselines_energyplus.common.plot_energyplus
+```
+
+For more information, see also [this tutorial](http://wiki.ros.org/docker/Tutorials/GUI)


### PR DESCRIPTION
Signed-off-by: Antoine Galataud [antoine@foobot.io](mailto:antoine@foobot.io)

Add instructions to be able to run `python3 -m baselines_energyplus.common.plot_energyplus` from within a docker container